### PR TITLE
Exceptions in handlers

### DIFF
--- a/srcs/Moonlight/Handlers/Battle/SrPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Battle/SrPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Moonlight.Clients;
 using Moonlight.Game.Battle;
 using Moonlight.Packet.Battle;
@@ -9,6 +9,11 @@ namespace Moonlight.Handlers.Battle
     {
         protected override void Handle(Client client, SrPacket packet)
         {
+            if (client.Character == null || client.Character.Skills == null)
+            {
+                return;
+            }
+
             Skill skill = client.Character.Skills.FirstOrDefault(x => x.CastId == packet.CastId);
             if (skill == null)
             {

--- a/srcs/Moonlight/Handlers/Battle/SuPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Battle/SuPacketHandler.cs
@@ -23,6 +23,11 @@ namespace Moonlight.Handlers.Battle
 
         protected override void Handle(Client client, SuPacket packet)
         {
+            if (client.Character == null || client.Character.Map == null)
+            {
+                return;
+            }
+
             Map map = client.Character.Map;
 
             LivingEntity caster = map.GetEntity<LivingEntity>(packet.EntityType, packet.EntityId);
@@ -30,10 +35,13 @@ namespace Moonlight.Handlers.Battle
 
             if (caster is Character character)
             {
-                Skill skill = character.Skills.FirstOrDefault(x => x.Id == packet.SkillVnum);
-                if (skill != null)
+                if (character.Skills != null)
                 {
-                    skill.IsOnCooldown = true;
+                    Skill skill = character.Skills.FirstOrDefault(x => x.Id == packet.SkillVnum);
+                    if (skill != null)
+                    {
+                        skill.IsOnCooldown = true;
+                    }
                 }
             }
 

--- a/srcs/Moonlight/Handlers/Characters/AtPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Characters/AtPacketHandler.cs
@@ -15,6 +15,11 @@ namespace Moonlight.Handlers.Characters
 
         protected override void Handle(Client client, AtPacket packet)
         {
+            if (client.Character == null)
+            {
+                return;
+            }
+
             Character character = client.Character;
             if (packet.CharacterId != character.Id)
             {

--- a/srcs/Moonlight/Handlers/Characters/FactionPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Characters/FactionPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using Moonlight.Clients;
+using Moonlight.Clients;
 using Moonlight.Game.Entities;
 using Moonlight.Packet.Character;
 
@@ -10,7 +10,10 @@ namespace Moonlight.Handlers.Characters
         {
             Character character = client.Character;
 
-            character.Faction = packet.Faction;
+            if (character != null)
+            {
+                character.Faction = packet.Faction;
+            }
         }
     }
 }

--- a/srcs/Moonlight/Handlers/Characters/GoldPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Characters/GoldPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using Moonlight.Clients;
+using Moonlight.Clients;
 using Moonlight.Packet.Character;
 
 namespace Moonlight.Handlers.Characters
@@ -7,7 +7,10 @@ namespace Moonlight.Handlers.Characters
     {
         protected override void Handle(Client client, GoldPacket packet)
         {
-            client.Character.Gold = packet.Gold;
+            if (client.Character != null)
+            {
+                client.Character.Gold = packet.Gold;
+            }
         }
     }
 }

--- a/srcs/Moonlight/Handlers/Characters/Inventories/InvPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Characters/Inventories/InvPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using Moonlight.Clients;
+using Moonlight.Clients;
 using Moonlight.Core.Logging;
 using Moonlight.Game.Factory;
 using Moonlight.Game.Inventories;
@@ -19,6 +19,12 @@ namespace Moonlight.Handlers.Characters.Inventories
 
         protected override void Handle(Client client, InvPacket packet)
         {
+            if (client.Character == null || client.Character.Inventory == null)
+            {
+                return;
+            }
+
+
             Bag bag = client.Character.Inventory.GetBag(packet.BagType);
 
             if (bag == null)

--- a/srcs/Moonlight/Handlers/Characters/Inventories/IvnPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Characters/Inventories/IvnPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using Moonlight.Clients;
+using Moonlight.Clients;
 using Moonlight.Game.Entities;
 using Moonlight.Game.Factory;
 using Moonlight.Game.Inventories;
@@ -14,6 +14,11 @@ namespace Moonlight.Handlers.Characters.Inventories
 
         protected override void Handle(Client client, IvnPacket packet)
         {
+            if (client.Character == null || client.Character.Inventory == null)
+            {
+                return;
+            }
+
             Character character = client.Character;
             IvnSubPacket ivn = packet.SubPacket;
 

--- a/srcs/Moonlight/Handlers/Characters/LevPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Characters/LevPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using Moonlight.Clients;
+using Moonlight.Clients;
 using Moonlight.Game.Entities;
 using Moonlight.Packet.Character;
 
@@ -9,9 +9,11 @@ namespace Moonlight.Handlers.Characters
         protected override void Handle(Client client, LevPacket packet)
         {
             Character character = client.Character;
-
-            character.Level = packet.Level;
-            character.JobLevel = packet.JobLevel;
+            if (character != null)
+            {
+                character.Level = packet.Level;
+                character.JobLevel = packet.JobLevel;
+            }
         }
     }
 }

--- a/srcs/Moonlight/Handlers/Characters/SkiPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Characters/SkiPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Moonlight.Clients;
 using Moonlight.Core.Enums;
 using Moonlight.Game.Battle;
@@ -15,6 +15,11 @@ namespace Moonlight.Handlers.Characters
 
         protected override void Handle(Client client, SkiPacket packet)
         {
+            if (client.Character == null)
+            {
+                return;
+            }
+
             client.Character.Skills.Clear();
 
             var skills = new List<Skill>();

--- a/srcs/Moonlight/Handlers/Characters/SpPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Characters/SpPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using Moonlight.Clients;
+using Moonlight.Clients;
 using Moonlight.Game.Entities;
 using Moonlight.Packet.Character;
 
@@ -10,8 +10,11 @@ namespace Moonlight.Handlers.Characters
         {
             Character character = client.Character;
 
-            character.SpPoints = packet.Points;
-            character.AdditionalSpPoints = packet.AdditionalPoints;
+            if (character != null)
+            {
+                character.SpPoints = packet.Points;
+                character.AdditionalSpPoints = packet.AdditionalPoints;
+            }
         }
     }
 }

--- a/srcs/Moonlight/Handlers/Characters/StatPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Characters/StatPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using Moonlight.Clients;
+using Moonlight.Clients;
 using Moonlight.Event;
 using Moonlight.Event.Characters;
 using Moonlight.Game.Entities;
@@ -16,15 +16,18 @@ namespace Moonlight.Handlers.Characters
         {
             Character character = client.Character;
 
-            character.Hp = packet.Hp;
-            character.Mp = packet.Mp;
-            character.MaxHp = packet.MaxHp;
-            character.MaxMp = packet.MaxMp;
-
-            _eventManager.Emit(new StatChangeEvent(client)
+            if (character != null)
             {
-                Character = client.Character
-            });
+                character.Hp = packet.Hp;
+                character.Mp = packet.Mp;
+                character.MaxHp = packet.MaxHp;
+                character.MaxMp = packet.MaxMp;
+
+                _eventManager.Emit(new StatChangeEvent(client)
+                {
+                    Character = client.Character
+                });
+            }
         }
     }
 }

--- a/srcs/Moonlight/Handlers/Characters/WalkPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Characters/WalkPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Moonlight.Clients;
 using Moonlight.Core;
 using Moonlight.Game.Entities;
@@ -12,9 +12,12 @@ namespace Moonlight.Handlers.Characters
         {
             Character character = client.Character;
 
-            character.Speed = packet.Speed;
-            character.Position = new Position(packet.PositionX, packet.PositionY);
-            character.LastMovement = DateTime.Now;
+            if (character != null)
+            {
+                character.Speed = packet.Speed;
+                character.Position = new Position(packet.PositionX, packet.PositionY);
+                character.LastMovement = DateTime.Now;
+            }
         }
     }
 }

--- a/srcs/Moonlight/Handlers/Entities/CondPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Entities/CondPacketHandler.cs
@@ -9,7 +9,7 @@ namespace Moonlight.Handlers.Entities
     {
         protected override void Handle(Client client, CondPacket packet)
         {
-            Map map = client.Character.Map;
+            Map map = client.Character?.Map;
 
             LivingEntity entity = map?.GetEntity<LivingEntity>(packet.EntityType, packet.EntityId);
             if (entity == null)

--- a/srcs/Moonlight/Handlers/Entities/MvPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Entities/MvPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using Moonlight.Clients;
+using Moonlight.Clients;
 using Moonlight.Core;
 using Moonlight.Event;
 using Moonlight.Event.Entities;
@@ -15,7 +15,7 @@ namespace Moonlight.Handlers.Entities
 
         protected override void Handle(Client client, MvPacket packet)
         {
-            LivingEntity entity = client.Character.Map.GetEntity<LivingEntity>(packet.EntityType, packet.EntityId);
+            LivingEntity entity = client.Character?.Map?.GetEntity<LivingEntity>(packet.EntityType, packet.EntityId);
 
             if (entity == null)
             {

--- a/srcs/Moonlight/Handlers/Maps/CMapPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Maps/CMapPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using Moonlight.Clients;
+using Moonlight.Clients;
 using Moonlight.Core.Logging;
 using Moonlight.Event;
 using Moonlight.Event.Maps;
@@ -30,7 +30,7 @@ namespace Moonlight.Handlers.Maps
             }
             
             Map destination = _mapFactory.CreateMap(packet.MapId);
-            if (client.Character.Map?.Id == destination.Id)
+            if (client.Character?.Map?.Id == destination.Id)
             {
                 return;
             }

--- a/srcs/Moonlight/Handlers/Maps/DiePacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Maps/DiePacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using Moonlight.Clients;
+using Moonlight.Clients;
 using Moonlight.Core.Logging;
 using Moonlight.Game.Entities;
 using Moonlight.Game.Maps;
@@ -14,7 +14,7 @@ namespace Moonlight.Handlers.Maps
 
         protected override void Handle(Client client, DiePacket packet)
         {
-            Map map = client.Character.Map;
+            Map map = client.Character?.Map;
             if (map == null)
             {
                 return;

--- a/srcs/Moonlight/Handlers/Maps/GetPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Maps/GetPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using Moonlight.Clients;
+using Moonlight.Clients;
 using Moonlight.Game.Entities;
 using Moonlight.Game.Maps;
 using Moonlight.Packet.Map;
@@ -9,10 +9,10 @@ namespace Moonlight.Handlers.Maps
     {
         protected override void Handle(Client client, GetPacket packet)
         {
-            Map map = client.Character.Map;
+            Map map = client.Character?.Map;
 
-            LivingEntity entity = map.GetEntity<LivingEntity>(packet.EntityType, packet.EntityId);
-            GroundItem groundItem = map.GetEntity<GroundItem>(packet.DropId);
+            LivingEntity entity = map?.GetEntity<LivingEntity>(packet.EntityType, packet.EntityId);
+            GroundItem groundItem = map?.GetEntity<GroundItem>(packet.DropId);
 
             if (entity == null || groundItem == null)
             {

--- a/srcs/Moonlight/Handlers/Maps/GpPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Maps/GpPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using Moonlight.Clients;
+using Moonlight.Clients;
 using Moonlight.Core;
 using Moonlight.Game.Maps;
 using Moonlight.Packet.Map;
@@ -9,13 +9,9 @@ namespace Moonlight.Handlers.Maps
     {
         protected override void Handle(Client client, GpPacket packet)
         {
-            Map map = client.Character.Map;
-            if (map == null)
-            {
-                return;
-            }
+            Map map = client.Character?.Map;
 
-            map.AddPortal(new Portal(packet.PortalId, new Position(packet.SourceX, packet.SourceY), packet.DestinationId)
+            map?.AddPortal(new Portal(packet.PortalId, new Position(packet.SourceX, packet.SourceY), packet.DestinationId)
             {
                 Type = packet.PortalType
             });

--- a/srcs/Moonlight/Handlers/Maps/InPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Maps/InPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Moonlight.Clients;
 using Moonlight.Core;
 using Moonlight.Core.Enums;
@@ -27,7 +27,7 @@ namespace Moonlight.Handlers.Maps
 
         protected override void Handle(Client client, InPacket packet)
         {
-            Map map = client.Character.Map;
+            Map map = client.Character?.Map;
 
             if (map == null)
             {

--- a/srcs/Moonlight/Handlers/Maps/Minilands/Minigames/MlPtPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Maps/Minilands/Minigames/MlPtPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using Moonlight.Clients;
+using Moonlight.Clients;
 using Moonlight.Packet.Map.Miniland.Minigame;
 
 namespace Moonlight.Handlers.Maps.Minilands.Minigames
@@ -7,7 +7,10 @@ namespace Moonlight.Handlers.Maps.Minilands.Minigames
     {
         protected override void Handle(Client client, MlPtPacket packet)
         {
-            client.Character.ProductionPoints = packet.Points;
+            if (client.Character != null)
+            {
+                client.Character.ProductionPoints = packet.Points;
+            }
         }
     }
 }

--- a/srcs/Moonlight/Handlers/Maps/Minilands/Minigames/MloInfoPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Maps/Minilands/Minigames/MloInfoPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Moonlight.Clients;
 using Moonlight.Core;
@@ -16,7 +16,7 @@ namespace Moonlight.Handlers.Maps.Minilands.Minigames
 
         protected override void Handle(Client client, MloInfoPacket packet)
         {
-            var miniland = client.Character.Map as Miniland;
+            var miniland = client?.Character?.Map as Miniland;
 
             var minigame = miniland?.Objects.FirstOrDefault(x => x.Item.Vnum == packet.Vnum && x.Slot == packet.ObjectId) as Minigame;
             if (minigame == null)

--- a/srcs/Moonlight/Handlers/Maps/Minilands/MlInfoBrPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Maps/Minilands/MlInfoBrPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using Moonlight.Clients;
+using Moonlight.Clients;
 using Moonlight.Core.Logging;
 using Moonlight.Game.Maps;
 using Moonlight.Packet.Map.Miniland;
@@ -13,7 +13,7 @@ namespace Moonlight.Handlers.Maps.Minilands
 
         protected override void Handle(Client client, MlInfoBrPacket packet)
         {
-            var miniland = client.Character.Map as Miniland;
+            var miniland = client.Character?.Map as Miniland;
             if (miniland == null)
             {
                 _logger.Warn("Receiving packet but current map is not a miniland");

--- a/srcs/Moonlight/Handlers/Maps/Minilands/MlInfoPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Maps/Minilands/MlInfoPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using Moonlight.Clients;
+using Moonlight.Clients;
 using Moonlight.Core.Logging;
 using Moonlight.Game.Maps;
 using Moonlight.Packet.Map.Miniland;
@@ -11,7 +11,7 @@ namespace Moonlight.Handlers.Maps.Minilands
         {
             client.Character.ProductionPoints = packet.Points;
             
-            var miniland = client.Character.Map as Miniland;
+            var miniland = client.Character?.Map as Miniland;
             if (miniland == null)
             {
                 return;

--- a/srcs/Moonlight/Handlers/Maps/Minilands/MlObjLstPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Maps/Minilands/MlObjLstPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Moonlight.Clients;
 using Moonlight.Core;
 using Moonlight.Core.Logging;
@@ -25,7 +25,7 @@ namespace Moonlight.Handlers.Maps.Minilands
         {
             Character character = client.Character;
             
-            var miniland = character.Map as Miniland;
+            var miniland = character?.Map as Miniland;
             if (miniland == null)
             {
                 _logger.Info("Not in miniland");

--- a/srcs/Moonlight/Handlers/Maps/Minilands/MltObjPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Maps/Minilands/MltObjPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Moonlight.Clients;
 using Moonlight.Core;
 using Moonlight.Game.Entities;
@@ -18,7 +18,7 @@ namespace Moonlight.Handlers.Maps.Minilands
         {
             Character character = client.Character;
 
-            var miniland = character.Map as Miniland;
+            var miniland = character?.Map as Miniland;
             if (miniland == null)
             {
                 return;

--- a/srcs/Moonlight/Handlers/Maps/OutPacketHandler.cs
+++ b/srcs/Moonlight/Handlers/Maps/OutPacketHandler.cs
@@ -1,4 +1,4 @@
-﻿using Moonlight.Clients;
+using Moonlight.Clients;
 using Moonlight.Core.Logging;
 using Moonlight.Event;
 using Moonlight.Event.Maps;
@@ -21,7 +21,7 @@ namespace Moonlight.Handlers.Maps
 
         protected override void Handle(Client client, OutPacket packet)
         {
-            Map map = client.Character.Map;
+            Map map = client.Character?.Map;
 
             if (map == null)
             {


### PR DESCRIPTION
I noticed that before character initialization there is a lot of exceptions.
I don't really think that this is a good way to go. Handling exceptions can somehow slow down the process and it makes it harder to debug.

I disabled breaking on exceptions because of that and I didn't notice some mistakes I made myself. This wouldn't happen if I didn't have to disable those. (or well... if I made unit tests, right?...)

I think that there could be 2 solutions to this problem
1. Check if Character or smth is null in the handlers directly
2. Don't allow any handlers before character initialization

What do you think?