### PR TITLE
Add xunit.runner.visualstudio

### DIFF
--- a/tests/Moonlight.Tests.csproj
+++ b/tests/Moonlight.Tests.csproj
@@ -93,6 +93,11 @@
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>
     </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio">
+      <Version>2.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
I think that to make it possible to run the tests inside VS for everyone, this package is needed. I couldn't run the tests without it. There may be other workarounds, but why not just add the package?